### PR TITLE
feat(i18n): add internationalized routing

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -3,3 +3,4 @@ export * from "./provider";
 export { useI18nContext } from "./react";
 export * from "./types";
 export * from "./utilities";
+export * from "./with-i18n-routes";

--- a/src/i18n/with-i18n-routes.ts
+++ b/src/i18n/with-i18n-routes.ts
@@ -1,0 +1,57 @@
+import { type NextMiddleware, NextResponse } from "next/server";
+
+export type WithI18nRoutesOptions<
+  Locales extends readonly [string, ...string[]]
+> = {
+  locales: Locales;
+  routes: Partial<
+    Record<
+      string,
+      {
+        action: "redirect" | "rewrite";
+        destination: string;
+        locale: Locales[number];
+      }
+    >
+  >;
+};
+
+/**
+ * @see {@link https://nextjs.org/docs/advanced-features/i18n-routing#prefixing-the-default-locale Next.js Internationalized Routing}
+ */
+export const withI18nRoutes =
+  <Locales extends readonly [string, ...string[]]>(
+    options: WithI18nRoutesOptions<Locales>,
+    middleware?: NextMiddleware
+  ): NextMiddleware =>
+  (...parameters: Parameters<NextMiddleware>) => {
+    const [request] = parameters;
+
+    if (
+      request.nextUrl.pathname.startsWith("/_next") ||
+      request.nextUrl.pathname.includes("/api/") ||
+      /\.(.*)$/.test(request.nextUrl.pathname)
+    ) {
+      if (middleware) {
+        return middleware(...parameters);
+      }
+
+      return;
+    }
+
+    const url = request.nextUrl.clone();
+
+    const i18nRoute =
+      options.routes[request.nextUrl.href.slice(request.nextUrl.origin.length)];
+
+    if (i18nRoute) {
+      url.locale = i18nRoute.locale;
+      url.pathname = i18nRoute.destination;
+
+      return NextResponse[i18nRoute.action](
+        i18nRoute.action === "redirect"
+          ? new URL(i18nRoute.destination, request.url)
+          : url
+      );
+    }
+  };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,21 @@
+import { withI18nRoutes } from "@/i18n";
+
+export const config = {
+  matcher: "/:path*",
+};
+
+export const middleware = withI18nRoutes({
+  locales: ["en", "pl"] as const,
+  routes: {
+    "/sign-in": {
+      action: "rewrite",
+      destination: "/404",
+      locale: "pl",
+    },
+    "/zaloguj": {
+      action: "rewrite",
+      destination: "/sign-in",
+      locale: "pl",
+    },
+  },
+});


### PR DESCRIPTION
This pull request adds `withI18nRoutes` function that enables internationalized routing by utilizing [Next.js' Middleware](https://nextjs.org/docs/advanced-features/middleware).