### PR TITLE
chore: decouple context from request and response

### DIFF
--- a/src/server/authentication/get-server-session.ts
+++ b/src/server/authentication/get-server-session.ts
@@ -1,0 +1,9 @@
+import { GetServerSidePropsContext } from "next";
+import { unstable_getServerSession } from "next-auth";
+
+import { nextAuthOptions } from "./options";
+
+export const getServerSession = async (
+  request: GetServerSidePropsContext["req"],
+  response: GetServerSidePropsContext["res"]
+) => await unstable_getServerSession(request, response, nextAuthOptions);

--- a/src/server/authentication/index.ts
+++ b/src/server/authentication/index.ts
@@ -1,1 +1,2 @@
+export * from "./get-server-session";
 export * from "./options";


### PR DESCRIPTION
This pull request decouples [tRPC](https://trpc.io/docs/context) context from [Next.js' API](https://nextjs.org/docs/api-routes/introduction) `request` and `response`.