### PR TITLE
build: fix bundle analyzer's `enabled` option value

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,9 @@
+// @ts-check
+
 import bundleAnalyzer from "@next/bundle-analyzer";
 
 const withBundleAnalyzer = bundleAnalyzer({
-  enabled: process.env.ANALYZE_BUNDLE,
+  enabled: process.env.ANALYZE_BUNDLE === "true",
   openAnalyzer: false,
 });
 

--- a/src/types/environment.d.ts
+++ b/src/types/environment.d.ts
@@ -1,7 +1,7 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      ANALYZE_BUNDLE?: boolean;
+      ANALYZE_BUNDLE?: string;
       DATABASE_URL: string;
       GITHUB_CLIENT_ID: string;
       GITHUB_CLIENT_SECRET: string;


### PR DESCRIPTION
This pull request fixes a value of [@next/bundle-analyzer](https://github.com/vercel/next.js/tree/canary/packages/next-bundle-analyzer)'s `enabled` option caused by incorrect assumption of `ANALYZE_BUNDLE` environment variable's type.