### PR TITLE
fix: external URL condition for `Link` component

### DIFF
--- a/src/components/link.tsx
+++ b/src/components/link.tsx
@@ -34,7 +34,7 @@ export const Link: Component<LinkProps> = ({
         : "noreferrer"
       : rel;
 
-  if (typeof href === "string" && href.startsWith("/")) {
+  if (typeof href === "string" && !href.startsWith("/")) {
     return <a href={href} rel={rel} target={target} {...props} />;
   }
 


### PR DESCRIPTION
This pull request fixes external URL condition for `Link` component by adding a missing negation in front of the `href.startsWith("/")` statement.