### PR TITLE
chore: improve prettier configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@types/node": "18.0.0",
+    "@types/prettier": "^2.7.1",
     "@types/react": "18.0.14",
     "@types/react-dom": "18.0.5",
     "@typescript-eslint/eslint-plugin": "^5.33.0",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,8 +3,8 @@
 /** @type {import("prettier").Options} */
 const prettierConfig = {
   arrowParens: "always",
-  bracketSpacing: true,
   bracketSameLine: false,
+  bracketSpacing: true,
   jsxSingleQuote: false,
   plugins: [require("prettier-plugin-tailwindcss")],
   printWidth: 80,

--- a/src/types/vendor.d.ts
+++ b/src/types/vendor.d.ts
@@ -1,0 +1,1 @@
+declare module "prettier-plugin-tailwindcss";


### PR DESCRIPTION
This pull request improves [Prettier](https://prettier.io/) configuration. 
- Adds missing [`@types/prettier`](https://www.npmjs.com/package/@types/prettier) module.
- Adds [`prettier-plugin-tailwindcss`](https://github.com/tailwindlabs/prettier-plugin-tailwindcss) type declaration to a newly created `vendor.d.ts` file.
- Changes order of properties to remove the ESLint [`sort-keys/sort-keys-fix`](https://github.com/namnm/eslint-plugin-sort-keys) warning.
- [Renames the configuration file](https://prettier.io/docs/en/configuration.html) from `.prettierrc.js` to `prettier.config.js`.