### PR TITLE
refactor: remove `@db.Text` from `providerAccountId` field

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model Account {
     expiresAt         Int?      @map("expires_at")
     idToken           String?   @map("id_token") @db.Text
     provider          String    @db.Text
-    providerAccountId String    @map("provider_account_id") @db.Text
+    providerAccountId String    @map("provider_account_id")
     refreshToken      String?   @map("refresh_token") @db.Text
     scope             String?
     sessionState      String?   @map("session_state")


### PR DESCRIPTION
This pull request removes a native database type attribute `@db.Text` from `providerAccountId` field of `Account` model in Prisma schema to follow [NextAuth.js](https://next-auth.js.org/adapters/prisma#create-the-prisma-schema)' recommendation.