### PR TITLE
chore: disable renovate dashboard approval

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:js-app",
     ":assignAndReview(mateuszaliyev)",
-    ":dependencyDashboardApproval",
     ":label(build)",
     ":semanticCommits",
     ":semanticCommitScopeDisabled",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:js-app",
     ":assignAndReview(mateuszaliyev)",
     ":dependencyDashboardApproval",
     ":label(build)",
     ":semanticCommits",
     ":semanticCommitScopeDisabled",
-    ":semanticCommitType(build)"
+    ":semanticCommitTypeAll(build)"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
This pull request disables [Renovate](https://docs.renovatebot.com/) [dashboard approval](https://docs.renovatebot.com/presets-default/#dependencydashboardapproval) option.