### PR TITLE
chore: enable renovate dependency dashboard approval

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   "extends": [
     "config:js-app",
     ":assignAndReview(mateuszaliyev)",
+    ":dependencyDashboardApproval",
     ":label(build)",
     ":semanticCommits",
     ":semanticCommitScopeDisabled",


### PR DESCRIPTION
This pull request enables [Renovate Dependency Dashboard approval workflow](https://docs.renovatebot.com/presets-default/#dependencydashboardapproval).