### PR TITLE
refactor: rename `useI18nContext` to `useI18n`

### DIFF
--- a/src/components/meta.tsx
+++ b/src/components/meta.tsx
@@ -2,7 +2,7 @@ import NextHead from "next/head";
 
 import { useUrl } from "@/hooks/url";
 
-import { useI18nContext } from "@/i18n";
+import { useI18n } from "@/i18n";
 
 export type Font =
   | "black"
@@ -30,7 +30,7 @@ export type MetaProps = {
 };
 
 export const Meta = ({ description, preloadFonts = [], title }: MetaProps) => {
-  const { LL } = useI18nContext();
+  const { LL } = useI18n();
 
   const url = useUrl();
 

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -16,7 +16,7 @@ import {
 
 import { useMediaQuery } from "@/hooks/media-query";
 
-import { useI18nContext } from "@/i18n";
+import { useI18n } from "@/i18n";
 
 export type NavigationProps = HTMLAttributes<HTMLDivElement>;
 
@@ -25,7 +25,7 @@ export const Navigation = ({
   className,
   ...props
 }: NavigationProps) => {
-  const { LL } = useI18nContext();
+  const { LL } = useI18n();
 
   const session = useSession();
 

--- a/src/home/components/hero.tsx
+++ b/src/home/components/hero.tsx
@@ -7,7 +7,7 @@ import { Container } from "@/components/container";
 
 import { useMounted } from "@/hooks/mounted";
 
-import { useI18nContext } from "@/i18n";
+import { useI18n } from "@/i18n";
 
 import { Barrel } from "./barrel";
 
@@ -28,7 +28,7 @@ const IsometricPrismLogo = lazy(() =>
 );
 
 export const Hero = () => {
-  const { LL } = useI18nContext();
+  const { LL } = useI18n();
 
   const { resolvedTheme } = useTheme();
 

--- a/src/home/components/home.page.tsx
+++ b/src/home/components/home.page.tsx
@@ -10,7 +10,7 @@ import { Navigation, NavigationLink } from "@/components/navigation";
 import { OpenGraph } from "@/components/open-graph";
 import { Robots } from "@/components/robots";
 
-import { getI18nProps, useI18nContext } from "@/i18n";
+import { getI18nProps, useI18n } from "@/i18n";
 
 import { Hero } from "./hero";
 import { Partners } from "./partners";
@@ -24,7 +24,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => ({
 export const HomePage = () => {
   const [mounted, setMounted] = useState(false);
 
-  const { LL } = useI18nContext();
+  const { LL } = useI18n();
 
   const { setTheme, theme } = useTheme();
 

--- a/src/home/components/partners.tsx
+++ b/src/home/components/partners.tsx
@@ -9,7 +9,7 @@ import { Kicker } from "@/components/kicker";
 import { Link } from "@/components/link";
 import { Marquee } from "@/components/marquee";
 
-import { useI18nContext } from "@/i18n";
+import { useI18n } from "@/i18n";
 
 export type Partner = {
   href: string;
@@ -116,7 +116,7 @@ const partners: Partner[] = [
 ];
 
 export const Partners = () => {
-  const { LL } = useI18nContext();
+  const { LL } = useI18n();
 
   return (
     <section className="space-y-4 py-4">

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,6 +1,6 @@
 export * from "./get-i18n-props";
 export * from "./middleware";
 export * from "./provider";
-export { useI18nContext } from "./react";
+export { useI18nContext as useI18n } from "./react";
 export * from "./types";
 export * from "./utilities";

--- a/src/pages/sign-in.tsx
+++ b/src/pages/sign-in.tsx
@@ -2,7 +2,7 @@ import type { GetStaticProps } from "next";
 import Head from "next/head";
 import { signIn } from "next-auth/react";
 
-import { getI18nProps, useI18nContext } from "@/i18n";
+import { getI18nProps, useI18n } from "@/i18n";
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
@@ -11,7 +11,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => ({
 });
 
 const SignInPage = () => {
-  const { LL } = useI18nContext();
+  const { LL } = useI18n();
 
   return (
     <>


### PR DESCRIPTION
This pull request renames `useI18nContext` hook to `useI18n`.