### PR TITLE
chore: add `export` sorting eslint rule

### DIFF
--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -44,6 +44,7 @@ const eslintConfig = {
   ],
   rules: {
     "no-unused-vars": "off",
+    "simple-import-sort/exports": "warn",
     "simple-import-sort/imports": [
       "warn",
       {


### PR DESCRIPTION
This pull request adds [`simple-import-sort/exports`](https://github.com/lydell/eslint-plugin-simple-import-sort#exports) ESLint rule.