### PR TITLE
build: add dependency @types/eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "zod": "3.19.1"
   },
   "devDependencies": {
+    "@types/eslint": "^8.4.9",
     "@types/node": "18.11.8",
     "@types/prettier": "2.7.1",
     "@types/react": "18.0.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ specifiers:
   '@trpc/next': 10.0.0-rc.2
   '@trpc/react-query': 10.0.0-rc.2
   '@trpc/server': 10.0.0-rc.2
+  '@types/eslint': ^8.4.9
   '@types/node': 18.11.8
   '@types/prettier': 2.7.1
   '@types/react': 18.0.24
@@ -69,6 +70,7 @@ dependencies:
   zod: 3.19.1
 
 devDependencies:
+  '@types/eslint': 8.4.9
   '@types/node': 18.11.8
   '@types/prettier': 2.7.1
   '@types/react': 18.0.24
@@ -426,6 +428,17 @@ packages:
   /@trpc/server/10.0.0-rc.2:
     resolution: {integrity: sha512-qxtEoqXnF/eACW9c9/B/UJ+RkMz3QobKzwoYBamXxDf2LEENjdfWmj7cdHRC637LUAS6YS6WmD3Lol8SD8RiGg==}
     dev: false
+
+  /@types/eslint/8.4.9:
+    resolution: {integrity: sha512-jFCSo4wJzlHQLCpceUhUnXdrPuCNOjGFMQ8Eg6JXxlz3QaCKOb7eGi2cephQdM4XTYsNej69P9JDJ1zqNIbncQ==}
+    dependencies:
+      '@types/estree': 1.0.0
+      '@types/json-schema': 7.0.11
+    dev: true
+
+  /@types/estree/1.0.0:
+    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
+    dev: true
 
   /@types/json-schema/7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}


### PR DESCRIPTION
This pull request adds [`@types/eslint`](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/eslint) dependency required for TypeScript autocompletion inside of `.eslintrc.js` file.