### PR TITLE
refactor: make minor improvements

### DIFF
--- a/.typesafe-i18n.json
+++ b/.typesafe-i18n.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "https://unpkg.com/typesafe-i18n@5.15.0/schema/typesafe-i18n.json",
+   "$schema": "https://unpkg.com/typesafe-i18n@5.16.1/schema/typesafe-i18n.json",
    "adapter": "react",
    "adapterFileName": "react",
    "baseLocale": "en",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,6 @@ const withBundleAnalyzer = bundleAnalyzer({
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   experimental: {
-    browsersListForSwc: true,
     legacyBrowsers: false,
   },
   headers: async () => [

--- a/src/home/components/hero.tsx
+++ b/src/home/components/hero.tsx
@@ -1,5 +1,6 @@
-import { lazy, Suspense } from "react";
+import { Suspense } from "react";
 
+import dynamic from "next/dynamic";
 import { useTheme } from "next-themes";
 
 import { GradientButton } from "@/components/button";
@@ -11,12 +12,14 @@ import { useI18n } from "@/i18n";
 
 import { Barrel } from "./barrel";
 
-const IsometricPrismCanvas = lazy(() =>
-  import("@/components/isometric-prism/canvas").then(
-    ({ IsometricPrismCanvas }) => ({
-      default: IsometricPrismCanvas,
-    })
-  )
+const IsometricPrismCanvas = dynamic(
+  () =>
+    import("@/components/isometric-prism/canvas").then(
+      ({ IsometricPrismCanvas }) => ({ default: IsometricPrismCanvas })
+    ),
+  {
+    suspense: true,
+  }
 );
 
 export const Hero = () => {
@@ -91,31 +94,29 @@ export const Hero = () => {
             </div>
           </div>
           {/* <AnimatedLogo className="ml-auto hidden w-[480px] stroke-2 xl:block" /> */}
-          {isMounted() && (
-            <div className="ml-auto hidden w-[480px] stroke-2 [mask-image:url(/images/logo/logomark.svg)] [mask-repeat:no-repeat] xl:block">
-              <Suspense fallback={null}>
-                <IsometricPrismCanvas
-                  animationFrequency={0.5}
-                  background="#0ea5e9"
-                  height={480}
-                  hue={{
-                    max: 220,
-                    min: 200,
-                  }}
-                  lightness={{
-                    max: 53,
-                    min: 48,
-                  }}
-                  saturation={{
-                    max: 89,
-                    min: 83,
-                  }}
-                  size={40}
-                  width={480}
-                />
-              </Suspense>
-            </div>
-          )}
+          <div className="ml-auto hidden w-[480px] stroke-2 [mask-image:url(/images/logo/logomark.svg)] [mask-repeat:no-repeat] xl:block">
+            <Suspense fallback={null}>
+              <IsometricPrismCanvas
+                animationFrequency={0.5}
+                background="#0ea5e9"
+                height={480}
+                hue={{
+                  max: 220,
+                  min: 200,
+                }}
+                lightness={{
+                  max: 53,
+                  min: 48,
+                }}
+                saturation={{
+                  max: 89,
+                  min: 83,
+                }}
+                size={40}
+                width={480}
+              />
+            </Suspense>
+          </div>
         </Container>
       </div>
     </section>


### PR DESCRIPTION
This pull request makes minor improvements:

- Updates `.typesafe-i18n.json` file schema.
- Removes [deprecated `browsersListForSwc` experimental `next.config.mjs` property](https://github.com/vercel/next.js/releases/tag/v13.0.0).
- Replaces [`React.lazy()`](https://beta.reactjs.org/apis/react/lazy#suspense-for-code-splitting) with [`next/dynamic`](https://nextjs.org/docs/advanced-features/dynamic-import) with `suspense: true` when lazy loading `IsometricPrism` component.