### PR TITLE
fix: make shiki available at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 
+# shiki
+/src/content/mdx/shiki
+
 # visual studio code
 /.vscode

--- a/.prettierignore
+++ b/.prettierignore
@@ -37,5 +37,8 @@ yarn-error.log*
 # vercel
 .vercel
 
+# shiki
+/src/content/mdx/shiki
+
 # typescript
 *.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "dev": "next dev",
     "format": "prettier --config ./prettier.config.js --write \"**/*.{css,js,md,mjs,scss,ts,tsx}\"",
     "lint": "next lint",
-    "postinstall": "prisma generate",
+    "postinstall": "prisma generate && pnpm shiki:initialize",
     "prisma:generate": "prisma generate",
     "prisma:push": "prisma db push",
     "prisma:studio": "prisma studio -b none",
+    "shiki:initialize": "pnpm dlx mkdirp ./src/content/mdx/shiki && cp -r ./node_modules/shiki/{languages,themes} ./src/content/mdx/shiki/",
     "start": "next start",
     "typecheck": "tsc",
     "vscode:generate": "pnpm dlx tsx ./scripts/vscode.ts"

--- a/src/content/mdx/code.ts
+++ b/src/content/mdx/code.ts
@@ -1,0 +1,101 @@
+/**
+ * TODO: Simplify this solution using `experimental.outputFileTracingIncludes`
+ * when released.
+ *
+ * @see {@link https://nextjs.org/docs/advanced-features/output-file-tracing#caveats Output File Tracing Caveats}
+ * @see {@link https://github.com/vercel/next.js/pull/44605 Add top-level trace include/exclude config}
+ */
+
+import { readdir } from "fs/promises";
+import { join } from "path";
+
+import type { serialize } from "next-mdx-remote/serialize";
+
+import {
+  default as rehypePrettyCode,
+  type Options as RehypePrettyCodeOptions,
+} from "rehype-pretty-code";
+import { getHighlighter, type HighlighterOptions } from "shiki";
+
+import dark from "./themes/dark.json";
+import light from "./themes/light.json";
+
+type RehypeCode = NonNullable<
+  NonNullable<
+    NonNullable<Parameters<typeof serialize>[1]>["mdxOptions"]
+  >["rehypePlugins"]
+>[number];
+
+type RehypePrettyCodeNode = {
+  children: unknown[];
+  properties: {
+    className: string[];
+  };
+};
+
+let shikiPathRead = false;
+
+/**
+ * Shiki loads languages and themes using `fs` instead of `import`, so Next.js
+ * doesn't bundle them into production build. To work around, those files are
+ * copied over to the source code (`./src/content/mdx/shiki/*`) and the `paths`
+ * are updated accordingly.
+ *
+ * Note that they are only referenced on server side.
+ * @see {@link https://github.com/shikijs/shiki/issues/138#issuecomment-1057471160 Usage with Next.js SSR}
+ * @see {@link https://github.com/thien-do/memos.pub/blob/a3babb1f149f05c43012278331f885d81f5fcfac/lib/mdx/plugins/code.ts Sample code}
+ */
+const getShikiPath = () => join(process.cwd(), "./src/content/mdx/shiki");
+
+/**
+ * Read the Shiki assets so that Vercel will include them in the production
+ * bundle. This is required because shiki itself dynamically access these
+ * files, so Vercel doesn't know about them by default.
+ *
+ * `readdir` can be fired once and forgotten
+ */
+const readShikiPath = async () => {
+  if (shikiPathRead) return;
+  await readdir(getShikiPath());
+  shikiPathRead = true;
+};
+
+const rehypePrettyCodeOptions: Partial<RehypePrettyCodeOptions> = {
+  getHighlighter: async (options) => {
+    await readShikiPath();
+
+    /**
+     * This is technically not compatible with shiki's interface but necessary
+     * for `rehype-pretty-code` to work.
+     *
+     * @see {@link https://rehype-pretty-code.netlify.app/ Rehype Pretty Code (Custom Highlighter section)}
+     */
+    return getHighlighter({
+      ...(options as HighlighterOptions),
+      paths: {
+        languages: `${getShikiPath()}/languages/`,
+        themes: `${getShikiPath()}/themes/`,
+      },
+    });
+  },
+  onVisitHighlightedLine: (node: RehypePrettyCodeNode) => {
+    node.properties.className.push("highlighted");
+  },
+  onVisitHighlightedWord: (node: RehypePrettyCodeNode) => {
+    node.properties.className = ["word"];
+  },
+  onVisitLine: (node: RehypePrettyCodeNode) => {
+    if (node.children.length === 0) {
+      node.children = [{ type: "text", value: " " }];
+    }
+  },
+  theme: {
+    dark,
+    light,
+  } as unknown as Record<string, JSON>,
+};
+
+export const rehypeCode: RehypeCode = [
+  rehypePrettyCode,
+  rehypePrettyCodeOptions,
+];

--- a/src/content/mdx/serialize.ts
+++ b/src/content/mdx/serialize.ts
@@ -5,53 +5,23 @@ import {
   type Options as RehypeAutolinkHeadingsOptions,
 } from "rehype-autolink-headings";
 import rehypeKatex from "rehype-katex";
-import {
-  default as rehypePrettyCode,
-  type Options as RehypePrettyCodeOptions,
-} from "rehype-pretty-code";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 
-import dark from "./themes/dark.json";
-import light from "./themes/light.json";
-
-type RehypePrettyCodeNode = {
-  children: unknown[];
-  properties: {
-    className: string[];
-  };
-};
+import { rehypeCode } from "./code";
 
 const rehypeAutolinkHeadingsOptions: RehypeAutolinkHeadingsOptions = {
   behavior: "wrap",
 };
 
-const rehypePrettyCodeOptions: Partial<RehypePrettyCodeOptions> = {
-  onVisitHighlightedLine: (node: RehypePrettyCodeNode) => {
-    node.properties.className.push("highlighted");
-  },
-  onVisitHighlightedWord: (node: RehypePrettyCodeNode) => {
-    node.properties.className = ["word"];
-  },
-  onVisitLine: (node: RehypePrettyCodeNode) => {
-    if (node.children.length === 0) {
-      node.children = [{ type: "text", value: " " }];
-    }
-  },
-  theme: {
-    dark,
-    light,
-  } as unknown as Record<string, JSON>,
-};
-
-export const serializeMdx = async (source: string) =>
-  await serialize(source, {
+export const serializeMdx = (source: string) =>
+  serialize(source, {
     mdxOptions: {
       format: "mdx",
       rehypePlugins: [
         rehypeKatex,
-        [rehypePrettyCode, rehypePrettyCodeOptions],
+        rehypeCode,
         rehypeSlug,
         [rehypeAutolinkHeadings, rehypeAutolinkHeadingsOptions],
       ],


### PR DESCRIPTION
This pull request makes an attempt to fix errors occuring when trying to preview content.

[Shiki](https://github.com/shikijs/shiki) tries to dynamically access the theme/grammar files using [Node.js' `fs`](https://nodejs.org/api/fs.html) module instead of `import` or `require` statements, which can't be traced by Vercel's [nft](https://github.com/vercel/nft). Ttherefore those files are not being bundled causing a runtime error when trying to serialize MDX on demand.

A potential solution is to copy required files from `node_modules` to the source code and read them at build time, so they are correctly detected by nft and bundled.